### PR TITLE
Make ship name dynamic

### DIFF
--- a/doppler.hoon
+++ b/doppler.hoon
@@ -16,12 +16,12 @@
 ;html
   ;head
     ;meta(charset "utf-8");
-    ;title: ~litpub status
+    ;title: {<p.bek>} status
   ==
   ;body
   ;main
-    ;h1: ~litpub status
-      ;p: ~litpub is online with a base hash of {<.^(@uv %cz /=base/(scot %da now))>}
+    ;h1: {<p.bek>} status
+      ;p:  {<p.bek>} is online with a base hash of {<.^(@uv %cz /=base/(scot %da now))>}
     ==
   ==
 ==


### PR DESCRIPTION
Pulls ship name from `beak` rather than hard-coding it as `litpub`